### PR TITLE
[WIP] Add support for SEO split tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,20 @@ If we wanted to [uniformly distribute](https://en.wikipedia.org/wiki/Uniform_dis
 @Bean
 public Filter experimentFilter() {
     return ExperimentFilter.builder().build()
-        .prepare("test-cta", asList("old", "new"));
+        .prepare(new UserExperiment("test", asList(["a", "b"])));
 }
 ```
+
+If we wanted to uniformly distribute `a` and `b` variants for an experiment `test` across the request *paths* of our application, the configuration would be
+
+```java
+public Filter experimentFilter() {
+    return ExperimentFilter.builder().build()
+        .prepare(new SeoExperiment("test", asList(["a", "b"])));
+}
+```
+
+For a SeoExperiment a given path will always return the same variant (unless overridden by request parameters).
 
 ## Usage
 
@@ -78,8 +89,8 @@ In an experiment configuration like the following
 @Bean
 public Filter experimentFilter() {
     return ExperimentFilter.builder().build()
-        .prepare("test1", asList("a", "b"))
-        .prepare("test2", asList("c", "d"));
+        .prepare(new UserExperiment("test1", asList("a", "b")))
+        .prepare(new UserExperiment("test2", asList("c", "d")));
 }
 ```
 
@@ -93,7 +104,7 @@ Worth mentioning that if you have multiple experiments running and you want to f
 
 ## Advanced use
 
-You can use lambda functions to create more complex filters, so you will split your traffic only under controled circumstances.
+You can use lambda functions to create more complex filters, so you will split your traffic only under controlled circumstances.
 Let's imagine you want to run your test only for people visiting some urls starting with "/path":
 
 

--- a/src/main/java/com/transferwise/mitosis/Experiment.java
+++ b/src/main/java/com/transferwise/mitosis/Experiment.java
@@ -1,0 +1,47 @@
+package com.transferwise.mitosis;
+
+import javax.servlet.http.HttpServletRequest;
+import java.util.List;
+import java.util.function.Predicate;
+
+public abstract class Experiment {
+
+    private static final String NAME_FORMAT = "^[a-z](-?[a-z0-9])*$";
+
+    protected String name;
+    protected List<String> variants;
+    protected Predicate<HttpServletRequest> filter;
+
+    public Experiment(String name, List<String> variants, Predicate<HttpServletRequest> filter) {
+        assertValidName(name);
+        assertValidVariants(variants);
+
+        this.name = name;
+        this.variants = variants;
+        this.filter = filter;
+    }
+
+    public abstract String chooseVariant(HttpServletRequest request);
+
+    static void assertValidName(String name) {
+        if (!name.matches(NAME_FORMAT)) {
+            throw new RuntimeException("Invalid experiment name value " + name);
+        }
+    }
+
+    static void assertValidVariants(List<String> variants) {
+        if (variants == null) {
+            throw new RuntimeException("A list of variants must be provided");
+        }
+
+        if (variants.size() < 1) {
+            throw new RuntimeException("Experiment must contain at least one variant");
+        }
+
+        variants.forEach(Experiment::assertValidName);
+    }
+
+    public boolean isValidVariant(String variant) {
+        return variants.contains(variant);
+    }
+}

--- a/src/main/java/com/transferwise/mitosis/SeoExperiment.java
+++ b/src/main/java/com/transferwise/mitosis/SeoExperiment.java
@@ -1,0 +1,22 @@
+package com.transferwise.mitosis;
+
+import javax.servlet.http.HttpServletRequest;
+import java.util.List;
+import java.util.function.Predicate;
+
+public class SeoExperiment extends Experiment {
+
+    public SeoExperiment(String name, List<String> variants, Predicate<HttpServletRequest> filter) {
+        super(name, variants, filter);
+    }
+
+    public SeoExperiment(String name, List<String> variants) {
+        super(name, variants, null);
+    }
+
+    @Override
+    public String chooseVariant(HttpServletRequest request) {
+        int index = Math.abs(request.getServletPath().hashCode()) % variants.size();
+        return variants.get(index);
+    }
+}

--- a/src/main/java/com/transferwise/mitosis/UserExperiment.java
+++ b/src/main/java/com/transferwise/mitosis/UserExperiment.java
@@ -1,0 +1,28 @@
+package com.transferwise.mitosis;
+
+import javax.servlet.http.HttpServletRequest;
+import java.util.Iterator;
+import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.function.Predicate;
+
+public class UserExperiment extends Experiment
+{
+    public UserExperiment(String name, List<String> variants, Predicate<HttpServletRequest> filter) {
+        super(name, variants, filter);
+    }
+
+    public UserExperiment(String name, List<String> variants) {
+        super(name, variants, null);
+    }
+
+    @Override
+    public String chooseVariant(HttpServletRequest request) {
+        int index = ThreadLocalRandom.current().nextInt(variants.size());
+        Iterator<String> i = variants.iterator();
+        for (int j = 0; j < index; j++) {
+            i.next();
+        }
+        return i.next();
+    }
+}

--- a/src/test/java/com/transferwise/mitosis/ExperimentEngineSpec.groovy
+++ b/src/test/java/com/transferwise/mitosis/ExperimentEngineSpec.groovy
@@ -1,0 +1,84 @@
+package com.transferwise.mitosis;
+
+import spock.lang.Specification
+
+import javax.servlet.http.HttpServletRequest
+import java.util.function.Predicate;
+
+class ExperimentEngineSpec extends Specification {
+
+    private ExperimentEngine engine
+
+    def setup() {
+        engine = new ExperimentEngine()
+    }
+
+    def 'it generates variants for registered experiments'() {
+        setup:
+        Map<String, String> variants = new HashMap<>()
+        engine.register(new SeoExperiment('test1', ['a']))
+        engine.register(new UserExperiment('test2', ['b']))
+
+        when:
+        variants = engine.refreshVariants(variants, createRequestMock('path'))
+
+        then:
+        2 == variants.size()
+        variants.get('test1') == 'a'
+        variants.get('test2') == 'b'
+    }
+
+    def 'it applies experiment filters'() {
+        setup:
+        Map<String, String> variants = new HashMap<>()
+        engine.register(new UserExperiment('test1', ['a']))
+        engine.register(new UserExperiment('test2', ['b'], new Predicate<HttpServletRequest>() {
+            @Override
+            boolean test(HttpServletRequest request) {
+                return false
+            }
+        }))
+
+        when:
+        variants = engine.refreshVariants(variants, createRequestMock('path'))
+
+        then:
+        1 == variants.size()
+    }
+
+    def 'it does not override valid variants'() {
+        setup:
+        Map<String, String> variants = new HashMap<String, String>() {{ put('test', 'a') }}
+        engine.register(new UserExperiment('test', ['a', 'b', 'c', 'd']))
+
+        when: variants = engine.refreshVariants(variants, createRequestMock('path'))
+
+        then: variants.get('test', 'a')
+    }
+
+    def 'it overrides invalid variants'() {
+        setup:
+        Map<String, String> variants = new HashMap<String, String>() {{ put('test', 'b') }}
+        engine.register(new UserExperiment('test', ['a']))
+
+        when: variants = engine.refreshVariants(variants, createRequestMock('path'))
+
+        then: variants.get('test', 'a')
+    }
+
+    def 'it cleans invalid experiments'() {
+        setup:
+        Map<String, String> variants = new HashMap<String, String>() {{ put('test', 'a') }}
+
+        when: variants = engine.refreshVariants(variants, createRequestMock('path'))
+
+        then: variants.size() == 0
+    }
+
+    protected HttpServletRequest createRequestMock(path) {
+        def request = Mock(HttpServletRequest)
+        request.getServletPath() >> { path }
+
+        request
+    }
+}

--- a/src/test/java/com/transferwise/mitosis/ExperimentFilterSpec.groovy
+++ b/src/test/java/com/transferwise/mitosis/ExperimentFilterSpec.groovy
@@ -40,7 +40,7 @@ class ExperimentFilterSpec extends Specification {
 
     @Unroll
     def 'experiment name #name should be invalid'() {
-        when: filter.prepare(name, [])
+        when: filter.prepare(name, ['a'])
 
         then: thrown RuntimeException
 

--- a/src/test/java/com/transferwise/mitosis/SeoExperimentSpec.groovy
+++ b/src/test/java/com/transferwise/mitosis/SeoExperimentSpec.groovy
@@ -1,0 +1,74 @@
+package com.transferwise.mitosis;
+
+import spock.lang.Specification
+import spock.lang.Unroll
+
+import javax.servlet.http.HttpServletRequest;
+
+class SeoExperimentSpec extends Specification {
+
+    @Unroll
+    def 'experiment name #name should be invalid'() {
+        when: new SeoExperiment(name, [])
+
+        then: thrown RuntimeException
+
+        where: name << ['INVALID', 'with spaces']
+    }
+
+    @Unroll
+    def 'variant name #name should be invalid'() {
+        when: new SeoExperiment('valid', [name])
+
+        then: thrown RuntimeException
+
+        where: name << ['INVALID', 'with spaces']
+    }
+
+    def 'null variants should be invalid'() {
+        when: new SeoExperiment('test', null)
+
+        then: thrown RuntimeException
+    }
+
+    def 'empty variants should be invalid'() {
+        when: new SeoExperiment('test', [])
+
+        then: thrown RuntimeException
+    }
+
+    def 'it chooses a variant'() {
+        given: Experiment experiment = new SeoExperiment('test', ['a'])
+
+        when: String variant = experiment.chooseVariant(createRequestMock('path'))
+
+        then: "a" == variant
+    }
+
+    def 'variant is deterministic'() {
+        given: Experiment experiment = new SeoExperiment('test', ['a', 'b', 'c'])
+
+        when: String variant = experiment.chooseVariant(createRequestMock('path'))
+
+        then: 'a' == variant
+    }
+
+    def 'variant depends on path'() {
+        given: Experiment experiment = new SeoExperiment('test', ['a', 'b', 'c'])
+
+        when:
+            String variant1 = experiment.chooseVariant(createRequestMock('path1'))
+            String variant2 = experiment.chooseVariant(createRequestMock('path2'))
+
+        then:
+            'b' == variant1
+            'c' == variant2
+    }
+
+    protected HttpServletRequest createRequestMock(path) {
+        def request = Mock(HttpServletRequest)
+        request.getServletPath() >> { path }
+
+        request
+    }
+}

--- a/src/test/java/com/transferwise/mitosis/UserExperimentSpec.groovy
+++ b/src/test/java/com/transferwise/mitosis/UserExperimentSpec.groovy
@@ -1,0 +1,54 @@
+package com.transferwise.mitosis
+
+import spock.lang.Specification
+import spock.lang.Unroll
+
+import javax.servlet.http.HttpServletRequest;
+
+class UserExperimentSpec extends Specification {
+
+    @Unroll
+    def 'experiment name #name should be invalid'() {
+        when: new UserExperiment(name, [])
+
+        then: thrown RuntimeException
+
+        where: name << ['INVALID', 'with spaces']
+    }
+
+    @Unroll
+    def 'variant name #name should be invalid'() {
+        when: new UserExperiment('valid', [name])
+
+        then: thrown RuntimeException
+
+        where: name << ['INVALID', 'with spaces']
+    }
+
+    def 'null variants should be invalid'() {
+        when: new UserExperiment('test', null)
+
+        then: thrown RuntimeException
+    }
+
+    def 'empty variants should be invalid'() {
+        when: new UserExperiment('test', [])
+
+        then: thrown RuntimeException
+    }
+
+    def 'it chooses a variant'() {
+        given: Experiment experiment = new UserExperiment('test', ['a'])
+
+        when: String variant = experiment.chooseVariant(createRequestMock('path'))
+
+        then: "a" == variant
+    }
+
+    protected HttpServletRequest createRequestMock(path) {
+        def request = Mock(HttpServletRequest)
+        request.getServletPath() >> { path }
+
+        request
+    }
+}


### PR DESCRIPTION
SEO split tests differ from User split tests in that variant depends on
the path rather than the user. To evenly distribute the variants between
paths we hash the path then take the modulo of the number of variants
`variants.get(hash(path) % variants.size())`, this only works if there are
a large number of unique paths served by the same endpoint.