### PR TITLE
Add request filter to apply experiment to % of paths

### DIFF
--- a/src/main/java/com/transferwise/mitosis/RequestFilter.java
+++ b/src/main/java/com/transferwise/mitosis/RequestFilter.java
@@ -27,4 +27,8 @@ public class RequestFilter {
             return headerValue != null && headerValue.toLowerCase().contains(value.toLowerCase());
         };
     }
+
+    public static Predicate<HttpServletRequest> applyToPercentageOfPaths(int percentage) {
+        return request -> Math.abs(request.getServletPath().hashCode()) % 100 < percentage;
+    }
 }

--- a/src/test/java/com/transferwise/mitosis/RequestFilterSpec.groovy
+++ b/src/test/java/com/transferwise/mitosis/RequestFilterSpec.groovy
@@ -27,9 +27,27 @@ class RequestFilterSpec extends Specification {
             headerContains('special', 'irrelevant')   | false
     }
 
+    def 'it applies filter to percentage of paths'() {
+        expect:
+        int count = 0
+        for (int i = 0; i < reps; i++) {
+            if (applyToPercentageOfPaths(30).test(aRequest('path' + i, Locale.UK, 'GoogleBot'))) {
+                count++
+            }
+        }
+        count == result
+
+        where:
+        reps | result
+        10   | 4
+        100  | 32
+        1000 | 305
+    }
+
     private aRequest(path, locale, userAgent) {
         def r = Mock(HttpServletRequest)
         r.getRequestURI() >> path
+        r.getServletPath() >> path
         r.getLocale() >> locale
         r.getHeader('user-agent') >> userAgent
         r


### PR DESCRIPTION
Whether or not the filter will be applied depends on the hash of the
path string so the filter will be applied consitently for the same path