### PR TITLE
Set 'experiments' request attributes regardless of cookie consent

### DIFF
--- a/src/main/java/com/transferwise/mitosis/ExperimentEngine.java
+++ b/src/main/java/com/transferwise/mitosis/ExperimentEngine.java
@@ -14,6 +14,13 @@ public class ExperimentEngine {
         experiments.add(experiment);
     }
 
+    public Map<String, String> refreshSeoExperimentVariants(Map<String, String> variants, HttpServletRequest request) {
+        return experiments.stream()
+            .filter(e -> e instanceof SeoExperiment)
+            .filter(e -> e.filter == null || e.filter.test(request))
+            .collect(Collectors.toMap(e -> e.name, e -> refresh(e, request, variants.get(e.name))));
+    }
+
     public Map<String, String> refreshVariants(Map<String, String> variants, HttpServletRequest request) {
         return experiments.stream()
                 .filter(e -> e.filter == null || e.filter.test(request))

--- a/src/main/java/com/transferwise/mitosis/ExperimentEngine.java
+++ b/src/main/java/com/transferwise/mitosis/ExperimentEngine.java
@@ -14,11 +14,14 @@ public class ExperimentEngine {
         experiments.add(experiment);
     }
 
-    public Map<String, String> refreshSeoExperimentVariants(Map<String, String> variants, HttpServletRequest request) {
+    public Map<String, String> seoExperimentVariants(HttpServletRequest request) {
         return experiments.stream()
             .filter(e -> e instanceof SeoExperiment)
             .filter(e -> e.filter == null || e.filter.test(request))
-            .collect(Collectors.toMap(e -> e.name, e -> refresh(e, request, variants.get(e.name))));
+            .collect(Collectors.toMap(
+                e -> e.name,
+                e -> e.chooseVariant(request)
+            ));
     }
 
     public Map<String, String> refreshVariants(Map<String, String> variants, HttpServletRequest request) {

--- a/src/main/java/com/transferwise/mitosis/ExperimentFilter.java
+++ b/src/main/java/com/transferwise/mitosis/ExperimentFilter.java
@@ -151,17 +151,19 @@ public class ExperimentFilter implements Filter {
         HttpServletRequest request = (HttpServletRequest) servletRequest;
         HttpServletResponse response = (HttpServletResponse) servletResponse;
 
-        if (cookieConsentRequired() && !cookieConsentAccepted(request)) {
-            chain.doFilter(request, response);
-            return;
-        }
-
         if (blacklistPath != null && request.getServletPath().startsWith(blacklistPath)) {
             chain.doFilter(request, response);
             return;
         }
 
-        Map<String, String> experiments = experimentEngine.refreshVariants(existingExperiments(request), request);
+        boolean canSetCookies = canSetCookie(request);
+
+        Map<String, String> experiments;
+        if (canSetCookies) {
+            experiments = experimentEngine.refreshVariants(existingExperiments(request), request);
+        } else {
+            experiments = experimentEngine.refreshSeoExperimentVariants(existingExperiments(request), request);
+        }
 
         String parameterExperiments = servletRequest.getParameter(requestParameter);
         if (parameterExperiments != null) {
@@ -169,7 +171,9 @@ public class ExperimentFilter implements Filter {
         }
 
         request.setAttribute(requestAttribute, experiments);
-        response.addCookie(createCookie(experiments));
+        if (canSetCookies) {
+            response.addCookie(createCookie(experiments));
+        }
 
         chain.doFilter(request, response);
     }
@@ -183,6 +187,14 @@ public class ExperimentFilter implements Filter {
         }
 
         return all;
+    }
+
+    private boolean canSetCookie(HttpServletRequest request) {
+        if (cookieConsentRequired() && cookieConsentAccepted(request)) {
+            return true;
+        }
+
+        return !cookieConsentRequired();
     }
 
     private boolean cookieConsentRequired() {

--- a/src/main/java/com/transferwise/mitosis/ExperimentFilter.java
+++ b/src/main/java/com/transferwise/mitosis/ExperimentFilter.java
@@ -162,7 +162,7 @@ public class ExperimentFilter implements Filter {
         if (canSetCookies) {
             experiments = experimentEngine.refreshVariants(existingExperiments(request), request);
         } else {
-            experiments = experimentEngine.refreshSeoExperimentVariants(existingExperiments(request), request);
+            experiments = experimentEngine.seoExperimentVariants(request);
         }
 
         String parameterExperiments = servletRequest.getParameter(requestParameter);

--- a/src/test/java/com/transferwise/mitosis/ExperimentFilterSpec.groovy
+++ b/src/test/java/com/transferwise/mitosis/ExperimentFilterSpec.groovy
@@ -168,6 +168,14 @@ class ExperimentFilterSpec extends Specification {
         then: cookie.value == 'irrelevant'
     }
 
+    def 'it should set request attribute to empty map if no experiments configured'() {
+        setup:
+
+        when: doFilter()
+
+        then: experiments.isEmpty()  // as opposed to being null
+    }
+
     private setupCookie(Map map) {
         cookie.value = URLEncoder.encode(map
                 .collect { it.key + ExperimentSerializer.VARIANT_SEPARATOR + it.value}


### PR DESCRIPTION
If the ExperimentFilter is configured then the 'experiments' request
attribute should always be a map. The map may be empty if no
experiments are configured or if the cookie consent has not be accepted
by the user. It is better to have an empty map than a null value as it
prevents null pointer exceptions
 - in the code that checks the map for the existance of an experiment.
 - in Spring @RequestParameter arguments
 - in Thymeleaf templates

---

SEO experiments do not rely on cookies but do need the experiment
variants to be set in the 'experiments' request attribute. SEO
experiment variants should be set regardless of cookie consent status.